### PR TITLE
2.0.2 Increase Max tide.conf Add Nodes from 8 to 32

### DIFF
--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -8,22 +8,22 @@
 
 CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
 {
-    unsigned char rkey[128];
-    if (keylen <= 128) {
+    unsigned char rkey[512];
+    if (keylen <= 512) {
         memcpy(rkey, key, keylen);
-        memset(rkey + keylen, 0, 128 - keylen);
+        memset(rkey + keylen, 0, 512 - keylen);
     } else {
         CSHA512().Write(key, keylen).Finalize(rkey);
         memset(rkey + 64, 0, 64);
     }
 
-    for (int n = 0; n < 128; n++)
+    for (int n = 0; n < 512; n++)
         rkey[n] ^= 0x5c;
-    outer.Write(rkey, 128);
+    outer.Write(rkey, 512);
 
-    for (int n = 0; n < 128; n++)
+    for (int n = 0; n < 512; n++)
         rkey[n] ^= 0x5c ^ 0x36;
-    inner.Write(rkey, 128);
+    inner.Write(rkey, 512);
 }
 
 void CHMAC_SHA512::Finalize(unsigned char hash[OUTPUT_SIZE])

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1696,7 +1696,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
             return;
 
         // Add seed nodes if DNS seeds are all down (an infrastructure attack?).
-        if (addrman.size() == 0 && (GetTime() - nStart > 60)) {
+        if (addrman.size() == 0 && (GetTime() - nStart > 2)) {
             static bool done = false;
             if (!done) {
                 LogPrintf("Adding fixed seed nodes as DNS doesn't seem to be available.\n");

--- a/src/net.h
+++ b/src/net.h
@@ -56,9 +56,9 @@ static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4 * 1000 * 1000;
 /** Maximum length of strSubVer in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** Maximum number of automatic outgoing nodes */
-static const int MAX_OUTBOUND_CONNECTIONS = 8;
+static const int MAX_OUTBOUND_CONNECTIONS = 16;
 /** Maximum number of addnode outgoing nodes */
-static const int MAX_ADDNODE_CONNECTIONS = 8;
+static const int MAX_ADDNODE_CONNECTIONS = 32;
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */


### PR DESCRIPTION
https://github.com/barrystyle/UraniumX/commit/3d58d9316a8f178d881e5257c270832a39e263cb

Increase Max tide.conf Add Nodes from 8 to 32

Upgrade Hmac-Sha512 keys from 128 to 512 Bit Keys

Reduce DNS timeout from 60 to 2 seconds to search for new nodes from tide.conf